### PR TITLE
fixed me.numArgs renaming in example

### DIFF
--- a/doc/language/spork.html
+++ b/doc/language/spork.html
@@ -296,7 +296,7 @@ Command line arguments can also be used when using on-the-fly programming facili
 To access command line arguments within a ChucK program, use the <strong><font face="courier">me.args()</font></strong> and <strong><font face="courier">me.arg()</font></strong> functions.  
 <pre>
 // print out all arguments
-for( int i; i < me.numArgs(); i++ )
+for( int i; i < me.args(); i++ )
     &lt;&lt;&lt; me.arg( i ) &gt;&gt;&gt;;
 </pre>
 </p>


### PR DESCRIPTION
rename `me.numArgs` to `me.args` in example as well